### PR TITLE
Configure Renovate - abandoned

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,3 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json"
-  "asd": "asd"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "asdasd": "asd"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "asdasd": "asd"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "asd": "asd"
 }


### PR DESCRIPTION
## Action Required: Fix Renovate Configuration

There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.

Location: `renovate.json5`
Error type: The renovate configuration file contains some invalid settings
Message: `Invalid configuration option: packageRules[0].matchConfideance`


Once you have resolved this problem (in this onboarding branch), Renovate will return to providing you with a preview of your repository's configuration.